### PR TITLE
docker: do not use timenano attribute

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ class EventNotifier {
         };
       }
 
-      if (parseInt(event.timeNano) >= parseInt(notification.event.timeNano)) {
+      if (parseInt(event.time) >= parseInt(notification.event.time)) {
         notification.event = event;
         if (notification.fn) {
           clearTimeout(notification.fn);


### PR DESCRIPTION
docker 1.8.1 does not support the `timenano` attribute on events. Instead use the `time` attribute